### PR TITLE
Added configuration of the homepage

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -125,6 +125,8 @@ if __name__ == '__main__':
     if zeronet_path:
         kwargs["zeronet_path"] = zeronet_path
 
+    kwargs["homepage"] = config.get('global', 'homepage', fallback='1HeLLo4uzjaLetFx6NH3PMwFP3qbRbTf3D')
+
     # Start the PyQt application
     app = QApplication(sys.argv)
     mainWindow = MainWindow(**kwargs)

--- a/src/MainWindow.py
+++ b/src/MainWindow.py
@@ -12,7 +12,10 @@ import sys
 class MainWindow(QMainWindow):
 
     def __init__(self, *args, **kwargs):
-        url = "http://127.0.0.1:43110/1HeLLo4uzjaLetFx6NH3PMwFP3qbRbTf3D/"
+        self.homepage = kwargs["homepage"]
+        del kwargs["homepage"]
+
+        url = "http://127.0.0.1:43110/%s/" % self.homepage
         if "url" in kwargs:
             url = kwargs["url"]
             del kwargs["url"]
@@ -115,10 +118,10 @@ class MainWindow(QMainWindow):
         self.tabs.currentWidget().setUrl(QUrl(url))
 
     def go_home(self):
-        self.tabs.currentWidget().setUrl(QUrl("http://127.0.0.1:43110/1HeLLo4uzjaLetFx6NH3PMwFP3qbRbTf3D/"))
+        self.tabs.currentWidget().setUrl(QUrl("http://127.0.0.1:43110/%s/" % self.homepage))
 
     def new_tab_clicked(self):
-        self.add_new_tab("http://127.0.0.1:43110/1HeLLo4uzjaLetFx6NH3PMwFP3qbRbTf3D/", "Home")
+        self.add_new_tab("http://127.0.0.1:43110/%s/" % self.homepage, "Home")
 
     def get_link_url_from_context_menu(self):
         tab = self.tabs.currentWidget()
@@ -185,7 +188,7 @@ class MainWindow(QMainWindow):
 
     def close_tab(self, index):
         if self.tabs.count() == 1:
-            self.tabs.currentWidget().setUrl(QUrl("http://127.0.0.1:43110/1HeLLo4uzjaLetFx6NH3PMwFP3qbRbTf3D/"))
+            self.tabs.currentWidget().setUrl(QUrl("http://127.0.0.1:43110/%s/" % self.homepage))
             return
         self.tabs.removeTab(index)
 


### PR DESCRIPTION
Hello,

I added new feature. You can set up zeronet address of the homepage when you open the ZeronetBrowser.

Put variable `homepage`  in your configuration file (e.g. `~/.zeronet/zeronet.conf `) to change default homepage.
If homepage variable does not exist - default address `1HeLLo4uzjaLetFx6NH3PMwFP3qbRbTf3D` is used.


```
[global]
homepage=Mail.ZeroNetwork.bit
```

