### PR TITLE
Added use_internal_zeronet and zeronet_base_url config parameters

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -125,6 +125,8 @@ if __name__ == '__main__':
     if zeronet_path:
         kwargs["zeronet_path"] = zeronet_path
 
+    kwargs["homepage"] = config.get('global', 'homepage', fallback='1HeLLo4uzjaLetFx6NH3PMwFP3qbRbTf3D')
+
     # Start the PyQt application
     app = QApplication(sys.argv)
     mainWindow = MainWindow(**kwargs)

--- a/src/MainWindow.py
+++ b/src/MainWindow.py
@@ -12,7 +12,10 @@ import sys
 class MainWindow(QMainWindow):
 
     def __init__(self, *args, **kwargs):
-        url = "http://127.0.0.1:43110/1HeLLo4uzjaLetFx6NH3PMwFP3qbRbTf3D/"
+        self.homepage = kwargs["homepage"]
+        del kwargs["homepage"]
+
+        url = "http://127.0.0.1:43110/%s/" % self.homepage
         if "url" in kwargs:
             url = kwargs["url"]
             del kwargs["url"]
@@ -115,10 +118,10 @@ class MainWindow(QMainWindow):
         self.tabs.currentWidget().setUrl(QUrl(url))
 
     def go_home(self):
-        self.tabs.currentWidget().setUrl(QUrl("http://127.0.0.1:43110/1HeLLo4uzjaLetFx6NH3PMwFP3qbRbTf3D/"))
+        self.tabs.currentWidget().setUrl(QUrl("http://127.0.0.1:43110/%s/" % self.homepage))
 
     def new_tab_clicked(self):
-        self.add_new_tab("http://127.0.0.1:43110/1HeLLo4uzjaLetFx6NH3PMwFP3qbRbTf3D/", "Home")
+        self.add_new_tab("http://127.0.0.1:43110/%s/" % self.homepage, "Home")
 
     def get_link_url_from_context_menu(self):
         tab = self.tabs.currentWidget()
@@ -185,7 +188,7 @@ class MainWindow(QMainWindow):
 
     def close_tab(self, index):
         if self.tabs.count() == 1:
-            self.tabs.currentWidget().setUrl(QUrl("http://127.0.0.1:43110/1HeLLo4uzjaLetFx6NH3PMwFP3qbRbTf3D/"))
+            self.tabs.currentWidget().setUrl(QUrl("http://127.0.0.1:43110/%s/" % self.homepage))
             return
         self.tabs.removeTab(index)
 

--- a/src/MainWindow.py
+++ b/src/MainWindow.py
@@ -15,7 +15,10 @@ class MainWindow(QMainWindow):
         self.homepage = kwargs["homepage"]
         del kwargs["homepage"]
 
-        url = "http://127.0.0.1:43110/%s/" % self.homepage
+        self.zeronet_base_url = kwargs["zeronet_base_url"]
+        del kwargs["zeronet_base_url"]
+
+        url = "%s/%s/" % (self.zeronet_base_url, self.homepage)
         if "url" in kwargs:
             url = kwargs["url"]
             del kwargs["url"]
@@ -107,21 +110,23 @@ class MainWindow(QMainWindow):
         if url.startswith('zero://') :
             # ZeroNet protocol
             url_array = url.split('/')
-            url = 'http://127.0.0.1:43110/' + url_array[2]
-        elif url.startswith('http://'):
+            url = self.zeronet_base_url + '/' + url_array[2]
+        elif url.startswith('http://') or url.startswith('https://'):
             # http protocol
             pass
         else :
             # Nothing mentionned
-            url = 'http://127.0.0.1:43110/' + url
+            url = self.zeronet_base_url + '/' + url
+
+        print("Go to: " + url)
 
         self.tabs.currentWidget().setUrl(QUrl(url))
 
     def go_home(self):
-        self.tabs.currentWidget().setUrl(QUrl("http://127.0.0.1:43110/%s/" % self.homepage))
+        self.tabs.currentWidget().setUrl(QUrl("%s/%s/" % (self.zeronet_base_url, self.homepage)))
 
     def new_tab_clicked(self):
-        self.add_new_tab("http://127.0.0.1:43110/%s/" % self.homepage, "Home")
+        self.add_new_tab("%s/%s/" % (self.zeronet_base_url, self.homepage), "Home")
 
     def get_link_url_from_context_menu(self):
         tab = self.tabs.currentWidget()
@@ -160,13 +165,13 @@ class MainWindow(QMainWindow):
         if qurl.startswith('zero://'):
             # ZeroNet protocol
             url_array = qurl.split('/')
-            qurl = 'http://127.0.0.1:43110/' + url_array[2]
-        elif qurl.startswith('http://'):
+            qurl = self.zeronet_base_url + '/' + url_array[2]
+        elif qurl.startswith('http://') or qurl.startswith('https://'):
             # http protocol
             pass
         else :
             # Nothing mentionned
-            qurl = 'http://127.0.0.1:43110/' + qurl
+            qurl = self.zeronet_base_url + '/' + qurl
 
         currentTab = self.tabs.currentWidget()
         currentTab.loadFinished.connect(self.page_loaded)
@@ -188,7 +193,7 @@ class MainWindow(QMainWindow):
 
     def close_tab(self, index):
         if self.tabs.count() == 1:
-            self.tabs.currentWidget().setUrl(QUrl("http://127.0.0.1:43110/%s/" % self.homepage))
+            self.tabs.currentWidget().setUrl(QUrl("%s/%s/" % (self.zeronet_base_url, self.homepage)))
             return
         self.tabs.removeTab(index)
 


### PR DESCRIPTION
Hi,

You can run Zeronet and ZeronetBrowser separately.
I added option `use_internal_zeronet`. Default value is `True`. If the value is `False` the ZeroNet process is not started.
I added this option because in most of cases I use port forwarding via SSH, so I do not need to run ZeroNet client on my computer. The next reason listed below

The Second option is `zeronet_base_url`. When you set to `http://0net.io/` in config file you can browse ZeroNet using `http://0net.io` ZeroNet Proxy Server.

Config example:
```
[global]
use_internal_zeronet=False
zeronet_base_url=http://0net.io
```

BTY. This Pull requests includes #111 